### PR TITLE
Add update step to poetry builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,14 +10,14 @@ ways to do it.
 
 ### Static build
 
-1. Run `poetry shell` to build the dependencies and drop into a virtualenv.
+1. Run `poetry install` to build the dependencies.
 2. Run `poetry run task build` to build the documentation.
 3. Run `poetry run task serve` to serve the docs on port 8000 (or `poetry run
    task serve 8001` to use a different port of your choice).
 
 ### Watch mode build.
 
-1. Run `poetry shell` to build the dependencies and drop into a virtualenv.
+1. Run `poetry install` to build the dependencies.
 2. Run `poetry run task watch` to build and serve the docs on port 8000 (or
    `poetry run task watch PORT=8001` to use a different port of your choice).
    Changes to the documentation source code will cause an automatic rebuild.


### PR DESCRIPTION
`poetry shell` only dropped me into a virtual env. I had to run `poetry install` to build the dependencies. Based on the [documentation](https://python-poetry.org/docs/cli/#shell) this looks like expected behavior.
@brianhelba Does this reflect your experience?